### PR TITLE
update hd path

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -21,6 +21,6 @@ export const LocalConfig = {
 
 export const DefaultWalletOptoions = {
   bip39Password: "",
-  hdPaths: [stringToPath("m/44'/750'/0'/0/0")],
+  hdPaths: [stringToPath("m/44'/118'/0'/0/0")],
   prefix: "persistence",
 };


### PR DESCRIPTION
Update default hd path used during Secp256k1HdWallet init to make it work for the updated cointype 118